### PR TITLE
Allowing to throttle down Dialling.

### DIFF
--- a/suites/transport/stream_suite.go
+++ b/suites/transport/stream_suite.go
@@ -450,7 +450,10 @@ func SubtestStreamReset(t *testing.T, ta, tb transport.Transport, maddr ma.Multi
 	<-done
 }
 
-func SubtestStress1Conn1Stream1Msg(t *testing.T, ta, tb transport.Transport, maddr ma.Multiaddr, peerA peer.ID, rateLimit RateLimiter) {
+func SubtestStress1Conn1Stream1Msg(t *testing.T, ta, tb transport.Transport, maddr ma.Multiaddr, peerA peer.ID) {
+	SubtestStress1Conn1Stream1MsgThrottled(t, ta, tb, maddr, peerA, NewRateLimiter(0))
+}
+func SubtestStress1Conn1Stream1MsgThrottled(t *testing.T, ta, tb transport.Transport, maddr ma.Multiaddr, peerA peer.ID, rateLimit RateLimiter) {
 	SubtestStress(t, ta, tb, maddr, peerA, Options{
 		ConnNum:   1,
 		StreamNum: 1,
@@ -461,7 +464,10 @@ func SubtestStress1Conn1Stream1Msg(t *testing.T, ta, tb transport.Transport, mad
 	})
 }
 
-func SubtestStress1Conn1Stream100Msg(t *testing.T, ta, tb transport.Transport, maddr ma.Multiaddr, peerA peer.ID, rateLimit RateLimiter) {
+func SubtestStress1Conn1Stream100Msg(t *testing.T, ta, tb transport.Transport, maddr ma.Multiaddr, peerA peer.ID) {
+	SubtestStress1Conn1Stream100MsgThrottled(t, ta, tb, maddr, peerA, NewRateLimiter(0))
+}
+func SubtestStress1Conn1Stream100MsgThrottled(t *testing.T, ta, tb transport.Transport, maddr ma.Multiaddr, peerA peer.ID, rateLimit RateLimiter) {
 	SubtestStress(t, ta, tb, maddr, peerA, Options{
 		ConnNum:   1,
 		StreamNum: 1,
@@ -472,7 +478,10 @@ func SubtestStress1Conn1Stream100Msg(t *testing.T, ta, tb transport.Transport, m
 	})
 }
 
-func SubtestStress1Conn100Stream100Msg(t *testing.T, ta, tb transport.Transport, maddr ma.Multiaddr, peerA peer.ID, rateLimit RateLimiter) {
+func SubtestStress1Conn100Stream100Msg(t *testing.T, ta, tb transport.Transport, maddr ma.Multiaddr, peerA peer.ID) {
+	SubtestStress1Conn100Stream100MsgThrottled(t, ta, tb, maddr, peerA, NewRateLimiter(0))
+}
+func SubtestStress1Conn100Stream100MsgThrottled(t *testing.T, ta, tb transport.Transport, maddr ma.Multiaddr, peerA peer.ID, rateLimit RateLimiter) {
 	SubtestStress(t, ta, tb, maddr, peerA, Options{
 		ConnNum:   1,
 		StreamNum: 100,
@@ -483,7 +492,10 @@ func SubtestStress1Conn100Stream100Msg(t *testing.T, ta, tb transport.Transport,
 	})
 }
 
-func SubtestStress50Conn10Stream50Msg(t *testing.T, ta, tb transport.Transport, maddr ma.Multiaddr, peerA peer.ID, rateLimit RateLimiter) {
+func SubtestStress50Conn10Stream50Msg(t *testing.T, ta, tb transport.Transport, maddr ma.Multiaddr, peerA peer.ID) {
+	SubtestStress50Conn10Stream50MsgThrottled(t, ta, tb, maddr, peerA, NewRateLimiter(0))
+}
+func SubtestStress50Conn10Stream50MsgThrottled(t *testing.T, ta, tb transport.Transport, maddr ma.Multiaddr, peerA peer.ID, rateLimit RateLimiter) {
 	SubtestStress(t, ta, tb, maddr, peerA, Options{
 		ConnNum:   50,
 		StreamNum: 10,
@@ -494,7 +506,10 @@ func SubtestStress50Conn10Stream50Msg(t *testing.T, ta, tb transport.Transport, 
 	})
 }
 
-func SubtestStress1Conn1000Stream10Msg(t *testing.T, ta, tb transport.Transport, maddr ma.Multiaddr, peerA peer.ID, rateLimit RateLimiter) {
+func SubtestStress1Conn1000Stream10Msg(t *testing.T, ta, tb transport.Transport, maddr ma.Multiaddr, peerA peer.ID) {
+	SubtestStress1Conn1000Stream10MsgThrottled(t, ta, tb, maddr, peerA, NewRateLimiter(0))
+}
+func SubtestStress1Conn1000Stream10MsgThrottled(t *testing.T, ta, tb transport.Transport, maddr ma.Multiaddr, peerA peer.ID, rateLimit RateLimiter) {
 	SubtestStress(t, ta, tb, maddr, peerA, Options{
 		ConnNum:   1,
 		StreamNum: 1000,
@@ -505,7 +520,10 @@ func SubtestStress1Conn1000Stream10Msg(t *testing.T, ta, tb transport.Transport,
 	})
 }
 
-func SubtestStress1Conn100Stream100Msg10MB(t *testing.T, ta, tb transport.Transport, maddr ma.Multiaddr, peerA peer.ID, rateLimit RateLimiter) {
+func SubtestStress1Conn100Stream100Msg10MB(t *testing.T, ta, tb transport.Transport, maddr ma.Multiaddr, peerA peer.ID) {
+	SubtestStress1Conn100Stream100Msg10MBThrottled(t, ta, tb, maddr, peerA, NewRateLimiter(0))
+}
+func SubtestStress1Conn100Stream100Msg10MBThrottled(t *testing.T, ta, tb transport.Transport, maddr ma.Multiaddr, peerA peer.ID, rateLimit RateLimiter) {
 	SubtestStress(t, ta, tb, maddr, peerA, Options{
 		ConnNum:   1,
 		StreamNum: 100,

--- a/suites/transport/utils_suite.go
+++ b/suites/transport/utils_suite.go
@@ -4,6 +4,7 @@ import (
 	"reflect"
 	"runtime"
 	"testing"
+	"time"
 
 	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/libp2p/go-libp2p-core/transport"
@@ -11,7 +12,7 @@ import (
 	ma "github.com/multiformats/go-multiaddr"
 )
 
-var Subtests = []func(t *testing.T, ta, tb transport.Transport, maddr ma.Multiaddr, peerA peer.ID){
+var Subtests = []interface{}{
 	SubtestProtocols,
 	SubtestBasic,
 	SubtestCancel,
@@ -33,13 +34,27 @@ func getFunctionName(i interface{}) string {
 }
 
 func SubtestTransport(t *testing.T, ta, tb transport.Transport, addr string, peerA peer.ID) {
+	SubtestTransportThrottled(t, ta, tb, addr, peerA, 0)
+}
+
+func SubtestTransportThrottled(t *testing.T, ta, tb transport.Transport, addr string, peerA peer.ID, throttle time.Duration) {
 	maddr, err := ma.NewMultiaddr(addr)
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	rateLimit := NewRateLimiter(throttle)
+
 	for _, f := range Subtests {
-		t.Run(getFunctionName(f), func(t *testing.T) {
-			f(t, ta, tb, maddr, peerA)
-		})
+		switch v := f.(type) {
+		case func(t *testing.T, ta, tb transport.Transport, maddr ma.Multiaddr, peerA peer.ID, rateLimit RateLimiter):
+			t.Run(getFunctionName(v), func(t *testing.T) {
+				v(t, ta, tb, maddr, peerA, rateLimit)
+			})
+		case func(t *testing.T, ta, tb transport.Transport, maddr ma.Multiaddr, peerA peer.ID):
+			t.Run(getFunctionName(v), func(t *testing.T) {
+				v(t, ta, tb, maddr, peerA)
+			})
+		}
 	}
 }

--- a/suites/transport/utils_suite.go
+++ b/suites/transport/utils_suite.go
@@ -19,12 +19,12 @@ var Subtests = []interface{}{
 	SubtestPingPong,
 
 	// Stolen from the stream muxer test suite.
-	SubtestStress1Conn1Stream1Msg,
-	SubtestStress1Conn1Stream100Msg,
-	SubtestStress1Conn100Stream100Msg,
-	SubtestStress50Conn10Stream50Msg,
-	SubtestStress1Conn1000Stream10Msg,
-	SubtestStress1Conn100Stream100Msg10MB,
+	SubtestStress1Conn1Stream1MsgThrottled,
+	SubtestStress1Conn1Stream100MsgThrottled,
+	SubtestStress1Conn100Stream100MsgThrottled,
+	SubtestStress50Conn10Stream50MsgThrottled,
+	SubtestStress1Conn1000Stream10MsgThrottled,
+	SubtestStress1Conn100Stream100Msg10MBThrottled,
 	SubtestStreamOpenStress,
 	SubtestStreamReset,
 }


### PR DESCRIPTION
So while finishing go-utp-transport I discovered golang is too good and was faster to dial than the accept loop was emptying the packet conn (so the kernel was maxing his buffer and reset conn).
While testing (anacrolix/go-libutp#13) I discovered that was due to loopback been way better than a real connection is capable to do (40Gbits/s for my laptop (I know infiniband QDR is capable to be that fast but that unprobable for 1 nodes to saturate 1 listener with 40GBits/s of data)).

If its choosed to add throttle down it need to be bigger than in reality because it only throttle dialling not the connection it self.

Its also maybe possible to use `tc` but I couldn't get it works properly with travis.