### PR TITLE
Add net benchmark harness

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,4 +5,5 @@ go 1.12
 require (
 	github.com/libp2p/go-libp2p-core v0.3.0
 	github.com/multiformats/go-multiaddr v0.2.0
+	google.golang.org/grpc v1.20.1
 )

--- a/go.sum
+++ b/go.sum
@@ -189,6 +189,7 @@ google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoA
 google.golang.org/genproto v0.0.0-20190307195333-5fe7a883aa19/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=
 google.golang.org/genproto v0.0.0-20190425155659-357c62f0e4bb/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
+google.golang.org/grpc v1.20.1 h1:Hz2g2wirWK7H0qIIhGIqRGTuMwTE8HEKFnDZZ7lm9NU=
 google.golang.org/grpc v1.20.1/go.mod h1:10oTOabMzJvdu6/UiuZezV6QK5dSlG84ov/aaiqXj38=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/net/bench.go
+++ b/net/bench.go
@@ -1,0 +1,115 @@
+package tnet
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc/benchmark/latency"
+)
+
+// NetworkTestFunc is a benchmark function under test by `FindNetworkLimit`
+type NetworkTestFunc func(b *testing.B, n1, n2 net.Conn)
+
+// ConnectionForNetwork generates a pair of network connections with a specified latency.
+func ConnectionForNetwork(n *latency.Network) (n1, n2 net.Conn, err error) {
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	var listener net.Listener
+	listener, err = net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return
+	}
+	slowListener := n.Listener(listener)
+	go func() {
+		defer wg.Done()
+		n2, _ = slowListener.Accept()
+		slowListener.Close()
+		return
+	}()
+	baseDialer := net.Dialer{}
+	dialer := n.ContextDialer(baseDialer.DialContext)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	n1, err = dialer(ctx, "tcp4", slowListener.Addr().String())
+	if err != nil {
+		return
+	}
+
+	wg.Wait()
+	return
+}
+
+// FindNetworkLimit benchmarks a function to analyze CPU, parallism, and network relationship
+func FindNetworkLimit(testFunc NetworkTestFunc) (float64, error) {
+	maxProcs := runtime.GOMAXPROCS(0)
+	runtime.GOMAXPROCS(maxProcs)
+	if maxProcs > 1 {
+		runtime.GOMAXPROCS(1)
+	}
+
+	network := latency.Network{
+		Kbps:    0,
+		Latency: 0,
+	}
+
+	wrapperFunc := func(sb *testing.B) {
+		n1, n2, err := ConnectionForNetwork(&network)
+		if err != nil {
+			sb.Error(err)
+		}
+		defer n1.Close()
+		defer n2.Close()
+		testFunc(sb, n1, n2)
+	}
+
+	result := testing.Benchmark(wrapperFunc)
+	if result.N < 1 {
+		return 0.0, fmt.Errorf("failed to run benchmark")
+	}
+	max := (float64(result.Bytes) * float64(result.N) / 1e6) / result.T.Seconds()
+	fmt.Printf("CPU Bound Limit: %s\n", result)
+
+	current := max
+	network.Latency = 500 * time.Microsecond
+	for current > max*0.9 {
+		network.Latency *= 2
+		result = testing.Benchmark(wrapperFunc)
+		current = (float64(result.Bytes) * float64(result.N) / 1e6) / result.T.Seconds()
+	}
+	fmt.Printf("Latency Bound Limit: %s\n", network.Latency)
+
+	network.Kbps = 1024 * 100 // 100Mbps
+	network.Latency /= 2
+	for current > max*0.9 {
+		network.Kbps /= 2
+		result = testing.Benchmark(wrapperFunc)
+		current = (float64(result.Bytes) * float64(result.N) / 1e6) / result.T.Seconds()
+	}
+	fmt.Printf("Bandwidth Bound Limit: %dKbps\n", network.Kbps)
+	fmt.Printf("Network Bound Limit: %s\n", result)
+
+	// Now, at a network-bounded level (divide bandwidth and latency by 10 as base)
+	// look at utilizations as a function of parallelism.
+	network.Latency *= 10
+	network.Kbps /= 10
+	prevBytes := int64(-1)
+	ratio := 1.0
+	for i := 1; i <= maxProcs; i *= 2 {
+		runtime.GOMAXPROCS(i)
+		result = testing.Benchmark(wrapperFunc)
+		if prevBytes > 0 {
+			ratio = float64(result.Bytes) / float64(prevBytes)
+		}
+		prevBytes = result.Bytes
+		fmt.Printf("At MaxProc %d %dKbps / %s latency: %s\n", i, network.Kbps, network.Latency, result)
+	}
+	fmt.Printf("Slowdown is %f%%\n", 100*(1.0-ratio))
+	return (1.0 - ratio), nil
+}


### PR DESCRIPTION
Factor some common testing infrastructure for evaluating yamux and mplex.

Example usage of `FindNetworkLimit` is to wrap it in a test, e.g.
```golang
func TestSmallPackets(t *testing.T) {
	slowdown, err := test.FindNetworkLimit(testSmallPackets)
	if err != nil {
		t.Fatal(err)
	}
	if slowdown > 0.01 {
		t.Fatalf("Slowdown from was >1%%: %f", slowdown)
	}
}
```

Tests will be added in `go-libp2p-yamux` and `go-libp2p-mplex` wrapping this. example output looks something like:
```
$ go test -run TestSmallPackets . -cpu 4 -v -benchtime 10s
go test -run TestSmallPackets . -cpu 4 -v -benchtime 10s
=== RUN   TestSmallPackets
CPU Bound Limit:   756516	     15630 ns/op	14714113.83 MB/s
Latency Bound Limit: 1ms
Bandwidth Bound Limit: 102400Kbps
Network Bound Limit:   667627	     18475 ns/op	10986033.14 MB/s
At MaxProc 1 10240Kbps / 5ms latency:    51513	    234283 ns/op	66800.22 MB/s
At MaxProc 2 10240Kbps / 5ms latency:    51474	    233296 ns/op	67018.94 MB/s
At MaxProc 4 10240Kbps / 5ms latency:    51253	    467991 ns/op	33285.00 MB/s
Slowdown is 0.372082%
--- PASS: TestSmallPackets (68.04s)
PASS
ok  	github.com/libp2p/go-mplex	68.664s
```

The basic mechanism this harness is implementing is first identifying how much the boundary between CPU-bound and Network-bound limitations of a given testing operation. Then, on the network-bound side of that boundary, increasing parallelism and watching the ratio of how utilized the network link is.

Notes: the output from the wrapped `testing.Benchmark` calls don't account for threads/processes properly - the reported `ns/op` and `MB/s` does a racy division on number of spawned threads, as far as i can tell. it ends up not particularly useful, but the overall bytes pushed over the network is bench-marked correctly across parallelism.