### PR TITLE
chore: Adding LICENSE.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,4 @@
+Dual-licensed under MIT and ASLv2, by way of the [Permissive License Stack](https://protocol.ai/blog/announcing-the-permissive-license-stack/).
+
+Apache-2.0: https://www.apache.org/licenses/license-2.0
+MIT: https://www.opensource.org/licenses/mit


### PR DESCRIPTION
This LICENSE was copied from https://github.com/libp2p/go-libp2p-core.

This is needed for [pkg.go.dev](https://pkg.go.dev/github.com/libp2p/go-libp2p-testing/) to display doc (right now I can only use godoc). Could it also be possible to publish a v0.3.1 with the LICENSE ? (for pkg.go.dev)