### PR TITLE
Defer closing stream for reading

### DIFF
--- a/suites/transport/stream_suite.go
+++ b/suites/transport/stream_suite.go
@@ -55,7 +55,7 @@ type Options struct {
 }
 
 func fullClose(t *testing.T, s mux.MuxedStream) {
-	if err := s.Close(); err != nil {
+	if err := s.CloseWrite(); err != nil {
 		t.Error(err)
 		s.Reset()
 		return
@@ -66,6 +66,9 @@ func fullClose(t *testing.T, s mux.MuxedStream) {
 	}
 	if len(b) != 0 {
 		t.Error("expected to be done reading")
+	}
+	if err := s.Close(); err != nil {
+		t.Error(err)
 	}
 }
 

--- a/suites/transport/transport_suite.go
+++ b/suites/transport/transport_suite.go
@@ -141,8 +141,8 @@ func SubtestBasic(t *testing.T, ta, tb transport.Transport, maddr ma.Multiaddr, 
 		t.Fatalf("failed to write enough data (a->b)")
 		return
 	}
-	err = s.Close()
-	if err != nil {
+
+	if err = s.CloseWrite(); err != nil {
 		t.Fatal(err)
 		return
 	}
@@ -154,6 +154,11 @@ func SubtestBasic(t *testing.T, ta, tb transport.Transport, maddr ma.Multiaddr, 
 	}
 	if !bytes.Equal(testData, buf) {
 		t.Errorf("expected %s, got %s", testData, buf)
+	}
+
+	if err = s.Close(); err != nil {
+		t.Fatal(err)
+		return
 	}
 }
 
@@ -265,7 +270,10 @@ func SubtestPingPong(t *testing.T, ta, tb transport.Transport, maddr ma.Multiadd
 				t.Error("failed to write enough data (a->b)")
 				return
 			}
-			s.Close()
+			if err = s.CloseWrite(); err != nil {
+				t.Fatal(err)
+				return
+			}
 
 			ret, err := ioutil.ReadAll(s)
 			if err != nil {
@@ -275,6 +283,11 @@ func SubtestPingPong(t *testing.T, ta, tb transport.Transport, maddr ma.Multiadd
 			}
 			if !bytes.Equal(data, ret) {
 				t.Errorf("expected %q, got %q", string(data), string(ret))
+			}
+
+			if err = s.Close(); err != nil {
+				t.Fatal(err)
+				return
 			}
 		}(i)
 	}


### PR DESCRIPTION
Hey there,

I'm trying to bring https://github.com/mtojek/go-libp2p-webrtc-star up to date ([fork](https://github.com/dennis-tra/go-libp2p-webrtc-star)) and now with updated dependencies, the transport test suite is failing.

I had a look at the test cases and noticed that there are reading attempts on already closed streams. I guess this wasn't a problem until [go-libp2p v0.12.0](https://github.com/libp2p/go-libp2p/releases/tag/v0.12.0):

> Previously, Close() closed streams for writing, but left them open for reading.
> [...]
> In this release, Close now closes the stream for both reading and writing.

In this PR I just deferred closing the reading side.