### PR TITLE
Address `go vet` and `saticcheck` issues

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -14,9 +14,7 @@ github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
-github.com/davecgh/go-spew v0.0.0-20171005155431-ecdeabc65495 h1:6IyqGr3fnd0tM3YxipK27TUskaOVUjU2nG45yzwcQKY=
 github.com/davecgh/go-spew v0.0.0-20171005155431-ecdeabc65495/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -62,7 +60,6 @@ github.com/minio/sha256-simd v0.1.1-0.20190913151208-6de447530771/go.mod h1:B5e1
 github.com/minio/sha256-simd v0.1.1 h1:5QHSlgo3nt5yKOJrC7W8w7X+NFl8cMPZm96iu8kKUJU=
 github.com/minio/sha256-simd v0.1.1/go.mod h1:B5e1o+1/KgNmWrSQK08Y6Z1Vb5pwIktudl0J58iy0KM=
 github.com/mr-tron/base58 v1.1.0/go.mod h1:xcD2VGqlgYjBdcBLw+TuYLr8afG+Hj8g2eTVqeSzSU8=
-github.com/mr-tron/base58 v1.1.3 h1:v+sk57XuaCKGXpWtVBX8YJzO7hMGx4Aajh4TQbdEFdc=
 github.com/mr-tron/base58 v1.1.3/go.mod h1:BinMc/sQntlIE1frQmRFPUoPA1Zkr8VRgBdjWI2mNwc=
 github.com/mr-tron/base58 v1.2.0 h1:T/HDJBh4ZCPbU39/+c3rRvE0uKBQlU27+QI8LJ4t64o=
 github.com/mr-tron/base58 v1.2.0/go.mod h1:BinMc/sQntlIE1frQmRFPUoPA1Zkr8VRgBdjWI2mNwc=
@@ -125,7 +122,6 @@ golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
-golang.org/x/sys v0.0.0-20190412213103-97732733099d h1:+R4KGOnez64A81RvjARKc4UT5/tI9ujCIVX+P5KiHuI=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190502145724-3ef323f4f1fd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190626221950-04f50cda93cb h1:fgwFCsaw9buMuxNd6+DQfAuSFqbNiQZpcgJQAgJsK6k=
@@ -136,7 +132,6 @@ golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGm
 golang.org/x/tools v0.0.0-20181030221726-6c7e314b6563/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190114222345-bf090417da8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3HoIrodX9oNMXvdceNzlUR8zjMvY=
-golang.org/x/tools v0.0.0-20190311212946-11955173bddd h1:/e+gpKk9r3dJobndpTytxS2gOy6m5uvpg+ISQoEcusQ=
 golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 golang.org/x/tools v0.0.0-20191029041327-9cc4af7d6b2c h1:IGkKhmfzcztjm6gYkykvu/NiS8kaqbCWAEWWAyf8J5U=
@@ -149,7 +144,6 @@ google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoA
 google.golang.org/genproto v0.0.0-20190425155659-357c62f0e4bb/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=
 google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55/go.mod h1:DMBHOl98Agz4BDEuKkezgsaosCRResVns1a3J2ZsMNc=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
-google.golang.org/grpc v1.20.1 h1:Hz2g2wirWK7H0qIIhGIqRGTuMwTE8HEKFnDZZ7lm9NU=
 google.golang.org/grpc v1.20.1/go.mod h1:10oTOabMzJvdu6/UiuZezV6QK5dSlG84ov/aaiqXj38=
 google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
 google.golang.org/grpc v1.25.1/go.mod h1:c3i+UQWmh7LiEpx4sFZnkU36qjEYZ0imhYfXVyQciAY=

--- a/net/bench.go
+++ b/net/bench.go
@@ -43,7 +43,6 @@ func ConnectionForNetwork(n *latency.Network) (n1, n2 *WriteTrackedConn, err err
 		ac, _ := slowListener.Accept()
 		slowListener.Close()
 		n2 = &WriteTrackedConn{ac, atomic.Uint32{}}
-		return
 	}()
 	baseDialer := net.Dialer{}
 	dialer := n.ContextDialer(baseDialer.DialContext)

--- a/suites/mux/muxer_suite.go
+++ b/suites/mux/muxer_suite.go
@@ -161,7 +161,7 @@ func SubtestSimpleWrite(t *testing.T, tr mux.Multiplexer) {
 
 func SubtestStress(t *testing.T, opt Options) {
 	msgsize := 1 << 11
-	errs := make(chan error, 0) // dont block anything.
+	errs := make(chan error) // dont block anything.
 
 	rateLimitN := 5000 // max of 5k funcs, because -race has 8k max.
 	rateLimitChan := make(chan struct{}, rateLimitN)
@@ -214,7 +214,7 @@ func SubtestStress(t *testing.T, opt Options) {
 
 		s, err := c.OpenStream(context.Background())
 		if err != nil {
-			errs <- fmt.Errorf("Failed to create NewStream: %s", err)
+			errs <- fmt.Errorf("failed to create NewStream: %s", err)
 			return
 		}
 
@@ -335,7 +335,8 @@ func SubtestStreamOpenStress(t *testing.T, tr mux.Multiplexer) {
 		defer wg.Done()
 		muxa, err := tr.NewConn(a, true)
 		if err != nil {
-			t.Fatal(err)
+			t.Error(err)
+			return
 		}
 		stress := func() {
 			defer wg.Done()

--- a/suites/sec/transport_suite.go
+++ b/suites/sec/transport_suite.go
@@ -149,7 +149,8 @@ func SubtestRW(t *testing.T, at, bt sec.SecureTransport, ap, bp peer.ID) {
 		c, err := at.SecureInbound(ctx, a)
 		if err != nil {
 			a.Close()
-			t.Fatal(err)
+			t.Error(err)
+			return
 		}
 
 		if c.LocalPeer() != ap {
@@ -167,7 +168,8 @@ func SubtestRW(t *testing.T, at, bt sec.SecureTransport, ap, bp peer.ID) {
 		c, err := bt.SecureOutbound(ctx, b, ap)
 		if err != nil {
 			b.Close()
-			t.Fatal(err)
+			t.Error(err)
+			return
 		}
 
 		if c.RemotePeer() != ap {
@@ -197,7 +199,8 @@ func SubtestKeys(t *testing.T, at, bt sec.SecureTransport, ap, bp peer.ID) {
 		c, err := at.SecureInbound(ctx, a)
 		if err != nil {
 			a.Close()
-			t.Fatal(err)
+			t.Error(err)
+			return
 		}
 		defer c.Close()
 
@@ -220,7 +223,8 @@ func SubtestKeys(t *testing.T, at, bt sec.SecureTransport, ap, bp peer.ID) {
 		c, err := bt.SecureOutbound(ctx, b, ap)
 		if err != nil {
 			b.Close()
-			t.Fatal(err)
+			t.Error(err)
+			return
 		}
 		defer c.Close()
 
@@ -251,18 +255,16 @@ func SubtestWrongPeer(t *testing.T, at, bt sec.SecureTransport, ap, bp peer.ID) 
 	go func() {
 		defer wg.Done()
 		defer a.Close()
-		_, err := at.SecureInbound(ctx, a)
-		if err == nil {
-			t.Fatal("conection should have failed")
+		if _, err := at.SecureInbound(ctx, a); err == nil {
+			t.Error("connection should have failed")
 		}
 	}()
 
 	go func() {
 		defer wg.Done()
 		defer b.Close()
-		_, err := bt.SecureOutbound(ctx, b, bp)
-		if err == nil {
-			t.Fatal("connection should have failed")
+		if _, err := bt.SecureOutbound(ctx, b, bp); err == nil {
+			t.Error("connection should have failed")
 		}
 	}()
 	wg.Wait()
@@ -278,9 +280,8 @@ func SubtestCancelHandshakeOutbound(t *testing.T, at, bt sec.SecureTransport, ap
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		_, err := at.SecureOutbound(ctx, a, ap)
-		if err == nil {
-			t.Fatal("connection should have failed")
+		if _, err := at.SecureOutbound(ctx, a, ap); err == nil {
+			t.Error("connection should have failed")
 		}
 	}()
 	time.Sleep(time.Millisecond)
@@ -288,9 +289,8 @@ func SubtestCancelHandshakeOutbound(t *testing.T, at, bt sec.SecureTransport, ap
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		_, err := bt.SecureInbound(ctx, b)
-		if err == nil {
-			t.Fatal("connection should have failed")
+		if _, err := bt.SecureInbound(ctx, b); err == nil {
+			t.Error("connection should have failed")
 		}
 	}()
 
@@ -308,9 +308,8 @@ func SubtestCancelHandshakeInbound(t *testing.T, at, bt sec.SecureTransport, ap,
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		_, err := at.SecureInbound(ctx, a)
-		if err == nil {
-			t.Fatal("connection should have failed")
+		if _, err := at.SecureInbound(ctx, a); err == nil {
+			t.Error("connection should have failed")
 		}
 	}()
 	time.Sleep(time.Millisecond)
@@ -318,9 +317,8 @@ func SubtestCancelHandshakeInbound(t *testing.T, at, bt sec.SecureTransport, ap,
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		_, err := bt.SecureOutbound(ctx, b, bp)
-		if err == nil {
-			t.Fatal("connection should have failed")
+		if _, err := bt.SecureOutbound(ctx, b, bp); err == nil {
+			t.Error("connection should have failed")
 		}
 	}()
 
@@ -343,7 +341,8 @@ func SubtestStream(t *testing.T, at, bt sec.SecureTransport, ap, bp peer.ID) {
 
 		c, err := at.SecureInbound(ctx, a)
 		if err != nil {
-			t.Fatal(err)
+			t.Error(err)
+			return
 		}
 
 		var swg sync.WaitGroup
@@ -364,7 +363,8 @@ func SubtestStream(t *testing.T, at, bt sec.SecureTransport, ap, bp peer.ID) {
 		defer wg.Done()
 		c, err := bt.SecureOutbound(ctx, b, ap)
 		if err != nil {
-			t.Fatal(err)
+			t.Error(err)
+			return
 		}
 		io.Copy(c, c)
 		c.Close()

--- a/suites/transport/stream_suite.go
+++ b/suites/transport/stream_suite.go
@@ -158,7 +158,7 @@ func goServe(t *testing.T, l transport.Listener) (done func()) {
 
 func SubtestStress(t *testing.T, ta, tb transport.Transport, maddr ma.Multiaddr, peerA peer.ID, opt Options) {
 	msgsize := 1 << 11
-	errs := make(chan error, 0) // dont block anything.
+	errs := make(chan error) // dont block anything.
 
 	rateLimitN := 5000 // max of 5k funcs, because -race has 8k max.
 	rateLimitChan := make(chan struct{}, rateLimitN)
@@ -211,7 +211,7 @@ func SubtestStress(t *testing.T, ta, tb transport.Transport, maddr ma.Multiaddr,
 
 		s, err := c.OpenStream(context.Background())
 		if err != nil {
-			errs <- fmt.Errorf("Failed to create NewStream: %s", err)
+			errs <- fmt.Errorf("failed to create NewStream: %s", err)
 			return
 		}
 

--- a/suites/transport/transport_suite.go
+++ b/suites/transport/transport_suite.go
@@ -8,7 +8,6 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/libp2p/go-libp2p-core/mux"
 	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/libp2p/go-libp2p-core/transport"
 
@@ -16,11 +15,6 @@ import (
 )
 
 var testData = []byte("this is some test data")
-
-type streamAndConn struct {
-	stream mux.MuxedStream
-	conn   transport.CapableConn
-}
 
 func SubtestProtocols(t *testing.T, ta, tb transport.Transport, maddr ma.Multiaddr, peerA peer.ID) {
 	rawIPAddr, _ := ma.NewMultiaddr("/ip4/1.2.3.4")
@@ -271,7 +265,7 @@ func SubtestPingPong(t *testing.T, ta, tb transport.Transport, maddr ma.Multiadd
 				return
 			}
 			if err = s.CloseWrite(); err != nil {
-				t.Fatal(err)
+				t.Error(err)
 				return
 			}
 
@@ -286,7 +280,7 @@ func SubtestPingPong(t *testing.T, ta, tb transport.Transport, maddr ma.Multiadd
 			}
 
 			if err = s.Close(); err != nil {
-				t.Fatal(err)
+				t.Error(err)
 				return
 			}
 		}(i)


### PR DESCRIPTION
Run `go mod tidy`

Resolve staticcheck issues:
- **SA2002** `t.Fatal`  must be called in the same goroutine as the test
- **U1000** unused struct
- **ST1005** error string should not be capitalized

The `go vet` issues were the same as the ones reported by `saticcheck`.

Relates to:
- https://github.com/orgs/ipfs/projects/12#card-58209321