### PR TITLE
fix deadlock in the transport's serve function

### DIFF
--- a/suites/transport/stream_suite.go
+++ b/suites/transport/stream_suite.go
@@ -138,12 +138,12 @@ func serve(t *testing.T, l transport.Listener) {
 		if err != nil {
 			return
 		}
+		defer c.Close()
 
 		wg.Add(1)
 		debugLog(t, "accepted connection")
 		go func() {
 			defer wg.Done()
-			defer c.Close()
 			echo(t, c)
 		}()
 	}

--- a/suites/transport/stream_suite.go
+++ b/suites/transport/stream_suite.go
@@ -241,13 +241,13 @@ func SubtestStress(t *testing.T, ta, tb transport.Transport, maddr ma.Multiaddr,
 			t.Error(err)
 			return
 		}
+		defer c.Close()
 
 		// serve the outgoing conn, because some muxers assume
 		// that we _always_ call serve. (this is an error?)
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			defer c.Close()
 			debugLog(t, "serving connection")
 			echo(t, c)
 		}()


### PR DESCRIPTION
We don't close the connection before the `echo` hasn't returned, but `echo` won't return before `AcceptStream` has returned an error, which only happens when the connection is closed.

This is what causes the failure with go-tcp-transport (https://github.com/libp2p/go-tcp-transport/issues/85).