### PR TITLE
release v0.9.0

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "v0.8.0"
+  "version": "v0.9.0"
 }


### PR DESCRIPTION
Unfortunately, this means that strictly speaking we won't be able to do a go-libp2p v0.18.1 release. Thanks semver 🙄